### PR TITLE
181 update was not fatal.  Just forced clients that got it to regen r…

### DIFF
--- a/documentation/changeLog.txt
+++ b/documentation/changeLog.txt
@@ -3,7 +3,7 @@ This file only list changes to game code.  Changes to content can be found here:
 http://onehouronelife.com/updateLog.php
 
 
-Version 182     2018-December-13
+Version 182     ???
 
 --Whoops... various headless helper apps failed to compile.  Fixed.
 

--- a/gameSource/game.cpp
+++ b/gameSource/game.cpp
@@ -1,4 +1,4 @@
-int versionNumber = 182;
+int versionNumber = 181;
 int dataVersionNumber = 0;
 
 // NOTE that OneLife doesn't use account hmacs


### PR DESCRIPTION
…everb and ground tile caches, and other caches.  So, just replace it with new 181 bundle that doesn't have this problem.