### PR TITLE
set mSayField text safely (reinterpret cast may not be null-terminated)

### DIFF
--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -20377,7 +20377,9 @@ void LivingLifePage::keyDown( unsigned char inASCII ) {
 	
 	if( isalpha( inASCII ) ) {
         if( ! mSayField.isFocused() ) {
-            mSayField.setText( reinterpret_cast<char*>( &inASCII ) );
+	     char text[2];
+	     sprintf(text, "%c", inASCII);
+            mSayField.setText(text);
             mSayField.focus();
         }
     }


### PR DESCRIPTION
Small bug that can cause garbled text to be written to the text screen. I.E. if p is hit PWGK... may be written instead of just P.